### PR TITLE
Use a different icon in Dev

### DIFF
--- a/ext/dev-icon.js
+++ b/ext/dev-icon.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const drawDevIcon = () => {
+  var canvas = document.createElement('canvas');
+  canvas.width = 128;
+  canvas.height = 128;
+
+  var ctx = canvas.getContext('2d');
+
+  var image = new Image();
+  image.src = chrome.runtime.getManifest().browser_action.default_icon;
+  image.onload = function() {
+    ctx.drawImage(image, 0, 0);
+
+    ctx.beginPath();
+    ctx.moveTo(128, 128);
+    ctx.lineTo(128, 30);
+    ctx.lineTo(30, 128);
+    ctx.globalAlpha = 0.4;
+    ctx.fillStyle = 'red';
+    ctx.fill();
+
+    chrome.browserAction.setIcon({
+      imageData: ctx.getImageData(0, 0, 128, 128)
+    });
+  };
+};
+
+chrome.management.getSelf((self) => {
+  if (self.installType === 'development') {
+    drawDevIcon();
+  }
+});

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -3,7 +3,7 @@
   "name": "Save workspaces",
   "description": "This extension saves the current windows tab for reusing it later similar to bookmarks.",
   "version": "1.0.2",
-  "background": { "scripts": ["hot-reload.js"] },
+  "background": { "scripts": ["hot-reload.js", "dev-icon.js"] },
   "browser_action": {
     "default_icon": "icon.png",
     "default_popup": "popup.html"


### PR DESCRIPTION
This is how it will look when having both extensions installed, the one from the webstore and the local one

 ![image](https://cloud.githubusercontent.com/assets/952074/26765777/bd5dcc8c-4959-11e7-8f0f-2b1667ac4f04.png)
